### PR TITLE
Make ACE editor widget expandable to 100% and configurable through settings

### DIFF
--- a/tablets/admin.py
+++ b/tablets/admin.py
@@ -19,10 +19,11 @@ from .models import Template
 class AceWidgetMixin(object):
     def formfield_for_dbfield(self, db_field, **kwargs):
         if getattr(settings, "USE_ACE_WIDGET", True) and db_field.name == "content":
-            kwargs["widget"] = AceWidget(mode=getattr(settings, "ACE_MODE", "twig"), theme=getattr(settings, "ACE_THEME", "chrome"))
-
+            kwargs["widget"] = AceWidget(mode=getattr(settings, "ACE_MODE", "twig"), 
+                                         theme=getattr(settings, "ACE_THEME", "chrome"),
+                                         width=getattr(settings, "ACE_WIDTH", "100%"),
+                                         height=getattr(settings, "ACE_HEIGHT", "300px"))
         return super(AceWidgetMixin, self).formfield_for_dbfield(db_field, **kwargs)
-
 
 class ChildInline(admin.TabularInline):
     model = Template


### PR DESCRIPTION
resolves issue #1. The editor can  now be properly expanded to the full width/height also.

in settings.py:

```
   ACE_WIDTH = "100%"
   ACE_HEIGHT = "500px"
```

If not set in settings.py, the defaults are 100% / 350px.
