### PR TITLE
Uses JINJA2_LOADER_SETTINGS, adds should_prioritize_filesystem, test requirements.txt fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,29 @@ INSTALLED_APPS = (
 
 JINJA2_TEMPLATE_CLASS = "django_jinja.base.Template"
 JINJA2_LOADER = "tablets.j2.loaders.Jinja2DatabaseOrFileLoader"
+JINJA2_LOADER_SETTINGS = {
+#    'should_prioritize_filesystem': False,
+#    'should_reload_database_templates: True,
+}
 ```
 
-Tablets reloads templates from the database each time. To turn off this functionality and only reload templates after an application reload, add this to your settings file:
+
+Tablets will by default check the database before the filesystem. To look for an existing file
+before checkint the database, change the value of `should_prioritize_filesystem` to True:
 ```py
 # Defaults to True
-JINJA2_SHOULD_RELOAD_DB_TEMPLATES = False
+JINJA2_LOADER_SETTINGS = {
+    'should_prioritize_filesystem': True,
+}
+```
+
+
+Tablets reloads templates from the database each time. To turn off this functionality and only reload templates after an application reload, change the value of `should_reload_database_templates` to False:
+```py
+# Defaults to True
+JINJA2_LOADER_SETTINGS = {
+    'should_reload_database_templates: False,
+}
 ```
 
 

--- a/tablets/j2/loaders.py
+++ b/tablets/j2/loaders.py
@@ -7,6 +7,8 @@ from django.template.loader import BaseLoader
 from django.template.loaders import app_directories
 from django.utils import six
 
+from jinja2.exceptions import TemplateNotFound
+
 default_loader_dirs = (app_directories.app_template_dirs +
                        tuple(settings.TEMPLATE_DIRS))
 
@@ -31,28 +33,49 @@ class Jinja2DatabaseOrFileLoader(FileSystemLoader):
     """
     This guy talks to the database and returns something Jinja2 wants.
     """
-    def __init__(self, searchpath=None, encoding='utf-8'):
+    def __init__(self, searchpath=None, encoding='utf-8', should_reload_db_templates=None, should_prioritize_filesystem=False):
         searchpath = searchpath or default_loader_dirs
         if isinstance(searchpath, six.string_types):
             searchpath = [searchpath]
         self.searchpath = list(searchpath)
         self.encoding = encoding
 
-    def get_source(self, environment, template):
+        if should_reload_db_templates is None:
+            # Backwards compatibility: if the parameter is not passed in via JINJA2_LOADER_SETTINGS,
+            # look for it using the old settings value.
+            should_reload_db_templates = getattr(settings, 'JINJA2_SHOULD_RELOAD_DB_TEMPLATES', True)
+
+        self.should_reload_db_templates = should_reload_db_templates
+        self.should_prioritize_filesystem = should_prioritize_filesystem
+
+    def uptodate(self):
+        return not self.should_reload_db_templates
+
+    def _load_from_database(self, environment, template):
         # Local Apps
         from tablets.models import Template
 
+        try:
+            tmpl = Template.objects.get(name=template, template_engine=Template.JINJA2)
+            return (tmpl.get_content().decode(self.encoding), template, self.uptodate)
+        except Template.DoesNotExist:
+            raise TemplateNotFound(template)
+
+    def get_source(self, environment, template):
         if not jinja2:
             raise Jinja2NotInstalled
 
-        def uptodate():
-            return not getattr(settings, "JINJA2_SHOULD_RELOAD_DB_TEMPLATES", True)
+        if self.should_prioritize_filesystem:
+            try:
+                return super(Jinja2DatabaseOrFileLoader, self).get_source(environment, template)
+            except TemplateNotFound:
+                return self._load_from_database(environment, template)
 
-        try:
-            tmpl = Template.objects.get(name=template, template_engine=Template.JINJA2)
-            return tmpl.get_content().decode(self.encoding), template, uptodate
-        except Template.DoesNotExist:
-            return super(Jinja2DatabaseOrFileLoader, self).get_source(environment, template)
+        else:
+            try:
+                return self._load_from_database(environment, template)
+            except TemplateNotFound:
+                return super(Jinja2DatabaseOrFileLoader, self).get_source(environment, template)
 
 
 class DjangoJinja2DatabaseLoader(BaseLoader):

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,10 +1,10 @@
-Django
+Django==1.6
 django-ace
 django-annoying
 django-model-utils
 django-mptt
 django-suit
-django-jinja
+django-jinja==1.0.1
 factory-boy
 html2text
 mock


### PR DESCRIPTION
Changes Jinja2 loader to use standard JINJA2_LOADER_SETTINGS.
- moves 'JINJA2_SHOULD_RELOAD_DB_TEMPLATES' to 'should_reload_db_templates' in JINJA2_LOADER_SETTINGS

Adds 'should_prioritize_filesystem' to allow the filesystem fallback to occur first if desired.

Fixes requirements.txt to pin working Django version at 1.6 and working django_jinja2 version at 1.0.1.

Moves j2/loader.py:Jinja2DatabaseOrFileLoader.uptodate to class level, as it doesn't need be a closure.
