### PR TITLE
fix exception when using django extensions' find_template command

### DIFF
--- a/tablets/loaders.py
+++ b/tablets/loaders.py
@@ -46,3 +46,8 @@ class DatabaseLoader(BaseLoader):
         else:
             from .j2.exceptions import DjangoJinjaNotInstalled
             raise DjangoJinjaNotInstalled
+
+    def load_template_source(self, template_name, template_dirs=None):
+        """ make django-extensions find_template work """
+        return (self.load_template(template_name, template_dirs), 
+                'django-tablets')


### PR DESCRIPTION
exception was as follows

```
# with django-extensions installed, this is Django 1.7
$ manage.py find_template app/template.html
(...)
raise NotImplementedError('subclasses of BaseLoader must provide a
load_template_source() method')
NotImplementedError: subclasses of BaseLoader must provide a load_template_source() method

```
